### PR TITLE
CDK-534: Switch demo crunch jobs to use views.

### DIFF
--- a/demo/demo-oozie/src/main/java/org/kitesdk/examples/demo/CreateSessions.java
+++ b/demo/demo-oozie/src/main/java/org/kitesdk/examples/demo/CreateSessions.java
@@ -15,18 +15,21 @@
  */
 package org.kitesdk.examples.demo;
 
-import org.kitesdk.data.Dataset;
-import org.kitesdk.data.DatasetRepositories;
-import org.kitesdk.data.DatasetRepository;
-import org.kitesdk.data.PartitionKey;
+import org.kitesdk.data.DatasetReader;
+import org.kitesdk.data.Datasets;
+import org.kitesdk.data.RefinableView;
+import org.kitesdk.data.View;
 import org.kitesdk.data.crunch.CrunchDatasets;
 import org.kitesdk.data.event.StandardEvent;
-import org.kitesdk.data.filesystem.FileSystemDatasetRepository;
 import org.kitesdk.examples.demo.event.Session;
-import com.google.common.collect.Iterables;
+import com.google.common.base.Splitter;
 import java.io.Serializable;
 import java.net.URI;
-import org.apache.crunch.CombineFn;
+import java.util.Calendar;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
 import org.apache.crunch.DoFn;
 import org.apache.crunch.Emitter;
 import org.apache.crunch.MapFn;
@@ -36,113 +39,146 @@ import org.apache.crunch.Target;
 import org.apache.crunch.types.avro.Avros;
 import org.apache.crunch.util.CrunchTool;
 import org.apache.hadoop.util.ToolRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CreateSessions extends CrunchTool implements Serializable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(CreateSessions.class);
+
   @Override
   public int run(String[] args) throws Exception {
-
-    // Construct a local filesystem dataset repository rooted at /tmp/data
-    DatasetRepository fsRepo = DatasetRepositories.open("repo:hdfs:/tmp/data");
-
-
-    // Construct an HCatalog dataset repository using external Hive tables
-    DatasetRepository hcatRepo = DatasetRepositories.open("repo:hive:/tmp/data");
-
     // Turn debug on while in development.
     getPipeline().enableDebug();
     getPipeline().getConfiguration().set("crunch.log.job.progress", "true");
 
-    // Load the events dataset and get the correct partition to sessionize
-    Dataset<StandardEvent> eventsDataset = fsRepo.load("events");
-    Dataset<StandardEvent> partition;
+    RefinableView<StandardEvent> eventsDataset = Datasets.load(
+        "dataset:hdfs:/tmp/data/events", StandardEvent.class);
+
+    View<StandardEvent> eventsToProcess;
     if (args.length == 0 || (args.length == 1 && args[0].equals("LATEST"))) {
-      partition = getLatestPartition(eventsDataset);
+      // get the current minute
+      Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+      cal.set(Calendar.SECOND, 0);
+      cal.set(Calendar.MILLISECOND, 0);
+      long end = cal.getTimeInMillis();
+      cal.roll(Calendar.MINUTE, -1);
+      long start = cal.getTimeInMillis();
+      // restrict events to the previous minute
+      eventsToProcess = eventsDataset
+          .from("timestamp", start).toBefore("timestamp", end);
+
     } else {
-      partition = getPartitionForURI(eventsDataset, args[0]);
+      eventsToProcess = viewFromUri(eventsDataset, args[0]);
+    }
+
+    if (isEmpty(eventsToProcess)) {
+      LOG.info("No records to process.");
+      return 0;
     }
 
     // Create a parallel collection from the working partition
     PCollection<StandardEvent> events = read(
-        CrunchDatasets.asSource(partition, StandardEvent.class));
+        CrunchDatasets.asSource(eventsToProcess));
 
-    // Process the events into sessions, using a combiner
+    // Group events by user and cookie id, then create a session for each group
     PCollection<Session> sessions = events
-      .parallelDo(new DoFn<StandardEvent, Session>() {
-        @Override
-        public void process(StandardEvent event, Emitter<Session> emitter) {
-          emitter.emit(Session.newBuilder()
-              .setUserId(event.getUserId())
-              .setSessionId(event.getSessionId())
-              .setIp(event.getIp())
-              .setStartTimestamp(event.getTimestamp())
-              .setDuration(0)
-              .setSessionEventCount(1)
-              .build());
-        }
-      }, Avros.specifics(Session.class))
-      .by(new MapFn<Session, Pair<Long, String>>() {
-        @Override
-        public Pair<Long, String> map(Session session) {
-          return Pair.of(session.getUserId(), session.getSessionId());
-        }
-      }, Avros.pairs(Avros.longs(), Avros.strings()))
-      .groupByKey()
-      .combineValues(new CombineFn<Pair<Long, String>, Session>() {
-        @Override
-        public void process(Pair<Pair<Long, String>, Iterable<Session>> pairIterable,
-            Emitter<Pair<Pair<Long, String>, Session>> emitter) {
-          String ip = null;
-          long startTimestamp = Long.MAX_VALUE;
-          long endTimestamp = Long.MIN_VALUE;
-          int sessionEventCount = 0;
-          for (Session s : pairIterable.second()) {
-            ip = s.getIp();
-            startTimestamp = Math.min(startTimestamp, s.getStartTimestamp());
-            endTimestamp = Math.max(endTimestamp, s.getStartTimestamp() + s.getDuration());
-            sessionEventCount += s.getSessionEventCount();
-          }
-          emitter.emit(Pair.of(pairIterable.first(), Session.newBuilder()
-              .setUserId(pairIterable.first().first())
-              .setSessionId(pairIterable.first().second())
-              .setIp(ip)
-              .setStartTimestamp(startTimestamp)
-              .setDuration(endTimestamp - startTimestamp)
-              .setSessionEventCount(sessionEventCount)
-              .build()));
-        }
-      })
-      .parallelDo(new DoFn<Pair<Pair<Long, String>, Session>, Session>() {
-        @Override
-        public void process(Pair<Pair<Long, String>, Session> pairSession,
-            Emitter<Session> emitter) {
-          emitter.emit(pairSession.second());
-        }
-      }, Avros.specifics(Session.class));
+        .by(new GetSessionKey(), Avros.strings())
+        .groupByKey()
+        .parallelDo(new MakeSession(), Avros.specifics(Session.class));
 
     // Write the sessions to the "sessions" Dataset
-    getPipeline().write(sessions, CrunchDatasets.asTarget(hcatRepo.load("sessions")),
+    getPipeline().write(sessions,
+        CrunchDatasets.asTarget("dataset:hive:/tmp/data/sessions"),
         Target.WriteMode.APPEND);
 
     return run().succeeded() ? 0 : 1;
   }
 
-  private <E> Dataset<E> getLatestPartition(Dataset<E> eventsDataset) {
-    Dataset<E> ds = eventsDataset;
-    while (ds.getDescriptor().isPartitioned()) {
-      ds = Iterables.getLast(ds.getPartitions());
+  private static class GetSessionKey extends MapFn<StandardEvent, String> {
+    @Override
+    public String map(StandardEvent event) {
+      // Create a key from the session id and user id
+      return event.getSessionId() + event.getUserId();
     }
-    return ds;
   }
 
-  private <E> Dataset<E> getPartitionForURI(Dataset<E> eventsDataset, String uri) {
-    PartitionKey partitionKey = FileSystemDatasetRepository.partitionKeyForPath(
-        eventsDataset, URI.create(uri));
-    Dataset<E> partition = eventsDataset.getPartition(partitionKey, false);
-    if (partition == null) {
-      throw new IllegalArgumentException("Partition not found: " + uri);
+  private static class MakeSession
+      extends DoFn<Pair<String, Iterable<StandardEvent>>, Session> {
+
+    @Override
+    public void process(
+        Pair<String, Iterable<StandardEvent>> keyAndEvents,
+        Emitter<Session> emitter) {
+      final Iterator<StandardEvent> events = keyAndEvents.second().iterator();
+      if (!events.hasNext()) {
+        return;
+      }
+
+      // Initialize the values needed to create a session for this group
+      final StandardEvent firstEvent = events.next();
+      long startTime = firstEvent.getTimestamp();
+      long endTime = firstEvent.getTimestamp();
+      int numEvents = 1;
+
+      // Inspect each event and keep track of start time, end time, and count
+      while (events.hasNext()) {
+        final StandardEvent event = events.next();
+        startTime = Math.min(startTime, event.getTimestamp());
+        endTime = Math.max(endTime, event.getTimestamp());
+        numEvents += 1;
+      }
+
+      // Create a session. Use the first event for fields that do not change
+      emitter.emit(Session.newBuilder()             // same on all events:
+          .setUserId(firstEvent.getUserId())        // the user id (grouped by)
+          .setSessionId(firstEvent.getSessionId())  // session id (grouped by)
+          .setIp(firstEvent.getIp())                // the source IP address
+          .setStartTimestamp(startTime)
+          .setDuration(endTime - startTime)
+          .setSessionEventCount(numEvents)
+          .build());
     }
-    return partition;
+  }
+
+  public static <E> View<E> viewFromUri(RefinableView<E> view, String uri) {
+    // helpers to parse the URI values
+    Splitter.MapSplitter splitter = Splitter.on('/').withKeyValueSeparator("=");
+    Pattern number = Pattern.compile("\\d+");
+
+    // the argument is a URI, with key/value pairs to restrict the view
+    URI location = view.getDataset().getDescriptor().getLocation();
+    URI path = location.resolve(URI.create(uri).getPath()); // handle different authority
+    String relative = location.relativize(path).toString();
+
+    for (Map.Entry<String, String> entry : splitter.split(relative).entrySet()) {
+      System.out.println("Key: '" + entry.getKey() + "'");
+      // if it looks like a number, add it as a number
+      if (number.matcher(entry.getValue()).matches()) {
+        view = view.with(entry.getKey(), Integer.valueOf(entry.getValue()));
+      } else {
+        view = view.with(entry.getKey(), entry.getValue());
+      }
+    }
+
+    System.out.println("View: " + view);
+
+    return view;
+  }
+
+  public boolean isEmpty(View<?> view) {
+    DatasetReader<?> reader = null;
+    try {
+      reader = view.newReader();
+      for (Object _ : reader) {
+        return true;
+      }
+      return false;
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
   }
 
   public static void main(String... args) throws Exception {


### PR DESCRIPTION
This implements the same command-line arguments as the previous version,
but the getLatestPartition method is replaced with viewFromUri. The new
version relativizes the URI and then uses the path's key/value pairs to
create a view.

The 'latest' partition is now time-based. Before, the newest partition
in the data was always used, but this wasn't correct and led to
duplicate sessions when the oozie job ran with no data. Because of this,
the demo-crunch tool differs slightly from the demo-oozie tool. The
demo-crunch tool will process everything before the current minute
without a lower bound. That ensures that running with no arguments
always processes some data rather than aborting because there was no
traffic in the last minute.

This depends on kite-data-core fixes for CDK-532 and CDK-536.
