### PR TITLE
CDK-726: Fixed doc issues in json, logging, and spark examples.

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -26,11 +26,11 @@ Flume needs to be able to impersonate the owner of the dataset it is writing to.
 (This is like Unix `sudo`, see
 [Configuring Flume's Security Properties](http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH5/latest/CDH5-Security-Guide/cdh5sg_flume_security_props.html#topic_4_2_1_unique_1)
 for further information.)
-    * If you're using Cloudera Manager (the QuickStart VM ships with Cloudera Manager,
-      but by default it is not enabled) then this is already configured for you.
-    * If you're not using Cloudera Manager, just add the following XML snippet to your
-      `/etc/hadoop/conf/core-site.xml` file and then restart the NameNode with
-      `sudo service hadoop-hdfs-namenode restart`.
+* If you're using Cloudera Manager (the QuickStart VM ships with Cloudera Manager,
+  but by default it is not enabled) then this is already configured for you.
+* If you're not using Cloudera Manager, just add the following XML snippet to your
+  `/etc/hadoop/conf/core-site.xml` file and then restart the NameNode with
+  `sudo service hadoop-hdfs-namenode restart`.
 
 ```
 <property>

--- a/logging/README.md
+++ b/logging/README.md
@@ -13,11 +13,11 @@ Flume needs to be able to impersonate the owner of the dataset it is writing to.
 (This is like Unix `sudo`, see
 [Configuring Flume's Security Properties](http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/latest/CDH4-Security-Guide/cdh4sg_topic_4_2.html)
 for further information.) 
-    * If you're using Cloudera Manager (the QuickStart VM ships with Cloudera Manager,
-      but by default it is not enabled) then this is already configured for you.
-    * If you're not using Cloudera Manager, just add the following XML snippet to your
-      `/etc/hadop/conf/core-site.xml` file and then restart the NameNode with
-      `sudo service hadoop-hdfs-namenode restart`.
+* If you're using Cloudera Manager (the QuickStart VM ships with Cloudera Manager,
+  but by default it is not enabled) then this is already configured for you.
+* If you're not using Cloudera Manager, just add the following XML snippet to your
+  `/etc/hadop/conf/core-site.xml` file and then restart the NameNode with
+  `sudo service hadoop-hdfs-namenode restart`.
 
 ```
 <property>

--- a/spark/README.md
+++ b/spark/README.md
@@ -121,7 +121,7 @@ You can browse the correlated events using [Hue on the QuickstartVM](http://loca
 When you're done or if you want to run the example again, you can delete the datasets we created:
 
 ```bash
-curl http://central.maven.org/maven2/org/kitesdk/kite-tools/0.16.0/kite-tools-0.16.0-binary.jar -o kite-dataset
+curl http://central.maven.org/maven2/org/kitesdk/kite-tools/0.17.0/kite-tools-0.17.0-binary.jar -o kite-dataset
 chmod +x kite-dataset
 ./kite-dataset delete events
 ./kite-dataset delete correlated_events


### PR DESCRIPTION
- Fixed formatting in the Flume setup instructions
- Fixed the downlaod location of the kite-dataset binary in spark
